### PR TITLE
Fix "Sequence contains no matching element" exception

### DIFF
--- a/GameEngine/Battleships/Domain/Players/BattleshipPlayer.cs
+++ b/GameEngine/Battleships/Domain/Players/BattleshipPlayer.cs
@@ -117,7 +117,7 @@ namespace Domain.Players
 
         public Weapon GetWeapon(WeaponType weaponType)
         {
-            var weapon = Ships.Where(x => !x.Destroyed).SelectMany(x => x.Weapons).First(x => x.WeaponType == weaponType);
+            var weapon = Ships.Where(x => !x.Destroyed).SelectMany(x => x.Weapons).FirstOrDefault(x => x.WeaponType == weaponType);
             if(weapon == null)
                 throw new ArgumentException($"Player has no active ships capable of firing weapon {weaponType}");
 

--- a/GameEngine/Battleships/GameEngine/Commands/PlayerCommands/FireShotCommand.cs
+++ b/GameEngine/Battleships/GameEngine/Commands/PlayerCommands/FireShotCommand.cs
@@ -42,7 +42,7 @@ namespace GameEngine.Commands.PlayerCommands
             }
             catch (Exception exception)
             {
-                throw new InvalidCommandException(exception.Message);
+                throw new InvalidCommandException(exception.Message, exception);
             }
         }
 


### PR DESCRIPTION
I regularly get a situation where a player tries to fire when they have no ships remaining and I get an InvalidOperationException "Sequence contains no matching element".

I think this is because the developer is using First() instead of FirstOrDefault() which throws an exception if no element is found, negating the next line of code which checks if the weapon returned is null.

Changing the function to FirstOrDefault will allow null to be returned and a more meaningful exception to be returned.

I also updated the Try...Catch block because the original exception's stacktrace was being lost.