### PR TITLE
Change OpponentMap ship types to string instead of enum.

### DIFF
--- a/GameEngine/Battleships/Domain/JSON/OpponentShip.cs
+++ b/GameEngine/Battleships/Domain/JSON/OpponentShip.cs
@@ -4,12 +4,16 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Domain.Games;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Domain.JSON
 {
     public class OpponentShip
     {
         public bool Destroyed { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
         public ShipType ShipType { get; set; }
     }
 }


### PR DESCRIPTION
The json state file currently sent to bots sends the OpponentMap ship types
as integers that correlate to the ShipType enum. This change renders the
ship types as the same strings found in the PlayerMap section of the
state and removes the need for the bot to correlate each number to the
ship it represents.

State before change:
![before](https://cloud.githubusercontent.com/assets/13220332/25225286/296f33d2-25c1-11e7-943e-9c5a5924f08f.png)

State after change:
![after](https://cloud.githubusercontent.com/assets/13220332/25225303/3b77ad3e-25c1-11e7-9db5-fa4f2ae551ba.png)

This is a quality of life change since it doesn't reveal any additional information from what I can tell. It simply conveys the same information in a better way.
