### PR TITLE
Update Game Engine to only pause on exit for Pretty sessions

### DIFF
--- a/GameEngine/Battleships/Battleships/Program.cs
+++ b/GameEngine/Battleships/Battleships/Program.cs
@@ -29,7 +29,10 @@ namespace Battleships
                     game.Logger = new CombinedLogger(new InMemoryLogger(), new ConsoleLogger());
                 }
                 game.StartNewGame(options);
-                Console.ReadLine();
+                if (options.Pretty)
+                {
+                    Console.ReadLine();
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Updated the game runner to only pause before exiting for game run with `--pretty`

Useful for when you want to run multiple tests between different versions of your bots in a batch file or script