### PR TITLE
Update OpponentShips.ShipType in Scala to be a string

### DIFF
--- a/Sample Bots/Scala/SampleBot/src/main/scala/za/co/sample/GameMapParser.scala
+++ b/Sample Bots/Scala/SampleBot/src/main/scala/za/co/sample/GameMapParser.scala
@@ -44,7 +44,7 @@ object GameMapParser {
                       )
   case class OpponentShips(
                     Destroyed: Boolean,
-                    ShipType: Int
+                    ShipType: String
                   )
   case class OpponentCells(
                     Damaged: Boolean,


### PR DESCRIPTION
Fix Scala bot with updated type for opponent ship after pull request #5.